### PR TITLE
添加自动发布工作流

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Create Release Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for the release'
+        required: true
+        default: 'v1.0.0'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Create release package
+      run: |
+        # 创建临时目录
+        mkdir -p release-temp/emby-ui-plugin
+        
+        # 复制需要的文件，排除开发相关文件
+        rsync -av --exclude='.git' \
+                  --exclude='.github' \
+                  --exclude='.trae' \
+                  --exclude='node_modules' \
+                  --exclude='*.log' \
+                  --exclude='.env*' \
+                  --exclude='docker-compose*.yml' \
+                  --exclude='Dockerfile*' \
+                  --exclude='.gitignore' \
+                  --exclude='*.md' \
+                  ./ release-temp/emby-ui-plugin/
+        
+        # 创建tar.gz包
+        cd release-temp
+        tar -czf ../emby-ui-plugin.tar.gz emby-ui-plugin/
+        cd ..
+        
+        # 验证包内容
+        echo "Package contents:"
+        tar -tzf emby-ui-plugin.tar.gz | head -20
+        
+        # 显示包大小
+        ls -lh emby-ui-plugin.tar.gz
+    
+    - name: Get tag name
+      id: get_tag
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          echo "tag_name=${{ github.event.inputs.tag_name }}" >> $GITHUB_OUTPUT
+        else
+          echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        fi
+    
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.get_tag.outputs.tag_name }}
+        release_name: Emby UI Plugin ${{ steps.get_tag.outputs.tag_name }}
+        body: |
+          ## Emby UI 美化插件 ${{ steps.get_tag.outputs.tag_name }}
+          
+          ### 📦 安装方法
+          
+          #### 方法一：直接下载
+          ```bash
+          wget https://github.com/zainzzz/emby-ui-plugin/releases/download/${{ steps.get_tag.outputs.tag_name }}/emby-ui-plugin.tar.gz
+          tar -xzf emby-ui-plugin.tar.gz
+          ```
+          
+          #### 方法二：Docker 集成
+          ```bash
+          # 下载并解压
+          wget https://github.com/zainzzz/emby-ui-plugin/releases/download/${{ steps.get_tag.outputs.tag_name }}/emby-ui-plugin.tar.gz
+          tar -xzf emby-ui-plugin.tar.gz
+          
+          # 复制到容器
+          docker cp emby-ui-plugin/ your-emby-container:/opt/emby-ui-plugin/
+          
+          # 执行安装
+          docker exec your-emby-container /opt/emby-ui-plugin/scripts/install-plugin.sh
+          
+          # 重启容器
+          docker restart your-emby-container
+          ```
+          
+          ### ✨ 主要特性
+          - 🎨 多主题支持（深色现代主题、浅色优雅主题）
+          - 🔧 高度可定制化配置
+          - 🐳 Docker 容器完美集成
+          - 📱 响应式设计，支持移动设备
+          - ⚡ 轻量级，不影响 Emby 性能
+          
+          ### 📋 系统要求
+          - Emby 版本：4.7.0+
+          - Docker：20.10+
+          - 现代浏览器支持
+          
+          ---
+          
+          **完整文档**: [README.md](https://github.com/zainzzz/emby-ui-plugin/blob/main/README.md)
+        draft: false
+        prerelease: false
+    
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./emby-ui-plugin.tar.gz
+        asset_name: emby-ui-plugin.tar.gz
+        asset_content_type: application/gzip


### PR DESCRIPTION
## 📦 添加 GitHub Actions 自动发布工作流

### 🎯 功能说明

这个 PR 添加了一个 GitHub Actions 工作流，用于自动创建发布包和 GitHub Release。

### ✨ 主要特性

- **自动触发**：当推送带有 `v*` 格式的标签时自动运行
- **手动触发**：支持通过 GitHub Actions 界面手动触发
- **智能打包**：自动排除开发相关文件（.git、.github、.trae、node_modules 等）
- **发布管理**：自动创建 GitHub Release 并上传 tar.gz 包
- **详细说明**：Release 包含完整的安装说明和特性介绍

### 📋 工作流程

1. **代码检出**：使用 `actions/checkout@v4` 获取最新代码
2. **创建包**：使用 `rsync` 和 `tar` 创建干净的发布包
3. **生成 Release**：自动创建 GitHub Release
4. **上传资源**：将 tar.gz 包作为 Release 资源上传

### 🚀 使用方法

#### 方法一：标签触发（推荐）
```bash
# 创建并推送标签
git tag v1.0.0
git push origin v1.0.0
```

#### 方法二：手动触发
1. 访问 GitHub Actions 页面
2. 选择 "Create Release Package" 工作流
3. 点击 "Run workflow"
4. 输入标签名称（如 v1.0.0）

### 📦 发布包内容

发布包将包含以下文件：
- 所有源代码文件（src/、themes/、scripts/ 等）
- 配置文件（plugin-config.json、theme-config.json 等）
- 许可证和基本文档
- 排除开发相关文件，确保包的干净和轻量

### 🔧 技术细节

- 使用 `rsync` 进行智能文件复制和排除
- 支持 `workflow_dispatch` 事件进行手动触发
- 自动生成详细的 Release 说明
- 包含完整的安装和使用指南

合并此 PR 后，您就可以通过创建标签来自动生成发布包了！